### PR TITLE
Display error to user if they enter an invalid game id.

### DIFF
--- a/client/src/components/Firebase/Firebase.js
+++ b/client/src/components/Firebase/Firebase.js
@@ -111,6 +111,10 @@ class Firebase {
     const gameDoc = await this.game(gameId).get();
     const game = gameDoc.data();
 
+    if (!gameDoc.exists) {
+      throw new Error('Invalid game ID');
+    }
+
     if (game.players.includes(this.auth.currentUser.uid)) {
       throw new Error('You\'re already in this game!');
     }


### PR DESCRIPTION
Instead of displaying a strange error to users when they enter an invalid game id, the page now tells them that the game id was invalid. 